### PR TITLE
Add bash to API Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:20-alpine
+RUN apk add --no-cache bash
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary
- install Bash in the API Docker image to support shell usage during container builds

## Testing
- docker compose build *(fails: docker CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3370c4b508324bc359f2616b6dbbf