### PR TITLE
Switch to Debian-based Node image for devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM node:20-alpine
-RUN apk add --no-cache bash
+FROM node:20-bookworm
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary
- switch the devcontainer image to node:20-bookworm so dpkg is available
- install bash using apt and clean up apt caches

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d33af828188324acf33f9f747fd675