### PR TITLE
chore: use devcontainer node image for api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm
+FROM mcr.microsoft.com/devcontainers/javascript-node:20
 RUN apt-get update \
     && apt-get install -y --no-install-recommends bash \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- switch the API Dockerfile to use the Debian-based devcontainer Node image

## Testing
- docker compose build *(fails: docker CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3492f9d708324969efdd1a023d135