### PR TITLE
Add Docker-in-Docker devcontainer template with Node API stack

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+# Install Docker engine and compose so the workspace can run Docker-in-Docker
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release \
+        docker.io \
+        docker-compose-plugin \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Coder Docker in Docker Workspace",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": ["--privileged"],
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    }
+  },
+  "postCreateCommand": "npm install --prefix api",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.vscode-node-azure-pack",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  },
+  "forwardPorts": [3000],
+  "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+npm-debug.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Ambiente Docker in Docker para Coder
+
+Este projeto provê um template completo de workspace Docker in Docker para uso no [Coder](https://coder.com/) com suporte a devcontainers. O ambiente entrega uma API Node.js 22 capaz de consumir simultaneamente SQL Server 2019 (Developer) e MongoDB 6, além de expor documentação via Swagger.
+
+## Componentes
+
+- **Devcontainer** configurado com Docker-in-Docker e Node.js 22 para uso no Visual Studio Code ou `code-server`.
+- **SQL Server 2019 Developer** com base `CoderClients`, tabela `Clients` e dados de exemplo.
+- **MongoDB 6** com base `coder` e usuário `apiuser` para autenticação da API.
+- **API Node.js 22** com autenticação básica e documentação Swagger disponível em `/docs`.
+
+## Requisitos de recursos
+
+Os limites de recursos são aplicados via `docker-compose.yml`:
+
+| Serviço    | Memória | CPU |
+|------------|---------|-----|
+| SQL Server | 2 GB    | 1   |
+| MongoDB    | 1 GB    | 0,5 |
+| API        | 1 GB    | 1   |
+
+> Observação: os limites são respeitados quando suportados pelo runtime Docker local.
+
+## Como usar
+
+1. Abra o repositório no Coder selecionando o template Docker-in-Docker e garantindo o suporte a devcontainer.
+2. Ao inicializar o workspace, o VS Code irá montar o devcontainer definido em `.devcontainer/devcontainer.json`.
+3. Dentro do container de desenvolvimento execute:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   Este comando iniciará o SQL Server, MongoDB e a API.
+
+4. Aguarde os logs indicarem que a API está pronta e acesse:
+
+   - `http://localhost:3000/docs` para visualizar a documentação Swagger.
+   - `http://localhost:3000/api/clients` usando autenticação básica `apiuser` / `apipassword123`.
+
+## Estrutura de pastas
+
+```
+.devcontainer/      # Configuração do ambiente de desenvolvimento Docker-in-Docker
+api/                # Código fonte da API Node.js 22
+mongo/init/         # Scripts de inicialização do MongoDB
+sql/init/           # Scripts de inicialização do SQL Server
+```
+
+## Variáveis de ambiente
+
+As principais variáveis estão definidas em `docker-compose.yml`. Ajuste conforme necessário:
+
+- `SQL_PASSWORD` / `MSSQL_SA_PASSWORD`: senha do usuário `sa`.
+- `MONGO_URI`: string de conexão utilizada pela API.
+- `AUTH_COLLECTION`: coleção MongoDB com usuários de autenticação.
+
+## Encerramento
+
+Para encerrar os serviços:
+
+```bash
+docker compose down
+```
+
+Isso removerá os containers criados, preservando scripts e código fonte.

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile
+.git

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        curl \
+        git \
+        iputils-ping \
+        nano \
+        netcat-openbsd \
+        procps \
+        vim \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install --production
+
+COPY . .
+
+EXPOSE 3000
+CMD ["node", "src/index.js"]

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "coder-clients-api",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "coder-clients-api",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2",
+        "mongodb": "^6.5.0",
+        "mssql": "^10.0.1",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.0"
+      },
+      "devDependencies": {
+        "nodemon": "^3.1.0"
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "coder-clients-api",
+  "version": "1.0.0",
+  "description": "API Node.js para consultar clientes usando SQL Server e MongoDB com autenticação básica",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "mongodb": "^6.5.0",
+    "mssql": "^10.0.1",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
+  }
+}

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -1,0 +1,48 @@
+const { getAuthCollection } = require('./db/mongoClient');
+
+async function verifyBasicAuth(header) {
+  if (!header || !header.startsWith('Basic ')) {
+    return null;
+  }
+
+  const base64Credentials = header.slice('Basic '.length).trim();
+  const credentials = Buffer.from(base64Credentials, 'base64').toString('utf-8');
+  const [username, password] = credentials.split(':');
+
+  if (!username || !password) {
+    return null;
+  }
+
+  const collection = await getAuthCollection();
+  const user = await collection.findOne({ username });
+  if (!user) {
+    return null;
+  }
+
+  if (user.password === password) {
+    return user;
+  }
+
+  return null;
+}
+
+async function authMiddleware(req, res, next) {
+  try {
+    const user = await verifyBasicAuth(req.headers.authorization);
+    if (!user) {
+      res.set('WWW-Authenticate', 'Basic realm="Clients API"');
+      return res.status(401).json({ message: 'Credenciais inválidas' });
+    }
+
+    req.user = user;
+    return next();
+  } catch (error) {
+    console.error('Erro na autenticação', error);
+    return res.status(500).json({ message: 'Erro interno de autenticação' });
+  }
+}
+
+module.exports = {
+  authMiddleware,
+  verifyBasicAuth
+};

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+
+const config = {
+  port: process.env.PORT || 3000,
+  sql: {
+    server: process.env.SQL_SERVER || 'sqlserver',
+    database: process.env.SQL_DATABASE || 'CoderClients',
+    user: process.env.SQL_USER || 'sa',
+    password: process.env.SQL_PASSWORD || 'StrongPassword!123',
+    encrypt: process.env.SQL_ENCRYPT === 'true',
+    options: {
+      trustServerCertificate: process.env.SQL_TRUST_CERT === 'true'
+    }
+  },
+  mongo: {
+    uri: process.env.MONGO_URI || 'mongodb://root:rootpassword@mongo:27017',
+    db: process.env.MONGO_DB || 'coder',
+    authCollection: process.env.AUTH_COLLECTION || 'users'
+  }
+};
+
+module.exports = config;

--- a/api/src/db/mongoClient.js
+++ b/api/src/db/mongoClient.js
@@ -1,0 +1,27 @@
+const { MongoClient } = require('mongodb');
+const config = require('../config');
+
+let cachedClient;
+
+async function getMongoClient() {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  const client = new MongoClient(config.mongo.uri, {
+    monitorCommands: false
+  });
+  await client.connect();
+  cachedClient = client;
+  return cachedClient;
+}
+
+async function getAuthCollection() {
+  const client = await getMongoClient();
+  return client.db(config.mongo.db).collection(config.mongo.authCollection);
+}
+
+module.exports = {
+  getMongoClient,
+  getAuthCollection
+};

--- a/api/src/db/sqlClient.js
+++ b/api/src/db/sqlClient.js
@@ -1,0 +1,34 @@
+const sql = require('mssql');
+const config = require('../config');
+
+let pool;
+
+async function getSqlPool() {
+  if (pool) {
+    return pool;
+  }
+
+  pool = await sql.connect({
+    server: config.sql.server,
+    user: config.sql.user,
+    password: config.sql.password,
+    database: config.sql.database,
+    options: {
+      encrypt: config.sql.encrypt,
+      trustServerCertificate: config.sql.options.trustServerCertificate
+    }
+  });
+
+  return pool;
+}
+
+async function getClients() {
+  const connection = await getSqlPool();
+  const result = await connection.request().query('SELECT Id, Name, Email, CreatedAt FROM dbo.Clients ORDER BY Id');
+  return result.recordset;
+}
+
+module.exports = {
+  getSqlPool,
+  getClients
+};

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,0 +1,77 @@
+const express = require('express');
+const swaggerUi = require('swagger-ui-express');
+const swaggerJsdoc = require('swagger-jsdoc');
+const config = require('./config');
+const { authMiddleware } = require('./auth');
+const { getClients } = require('./db/sqlClient');
+const { getMongoClient } = require('./db/mongoClient');
+
+const app = express();
+app.use(express.json());
+
+const swaggerDefinition = {
+  openapi: '3.0.3',
+  info: {
+    title: 'Clients API',
+    version: '1.0.0',
+    description: 'API para consulta de clientes integrando SQL Server e MongoDB com autenticação básica.'
+  },
+  servers: [
+    {
+      url: `http://localhost:${config.port}`,
+      description: 'Ambiente local'
+    }
+  ],
+  components: {
+    securitySchemes: {
+      basicAuth: {
+        type: 'http',
+        scheme: 'basic'
+      }
+    }
+  },
+  security: [
+    {
+      basicAuth: []
+    }
+  ]
+};
+
+const swaggerOptions = {
+  definition: swaggerDefinition,
+  apis: []
+};
+
+const swaggerSpec = swaggerJsdoc(swaggerOptions);
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+app.get('/health', async (_req, res) => {
+  try {
+    await Promise.all([
+      getMongoClient().then(client => client.db(config.mongo.db).command({ ping: 1 })),
+      getClients()
+    ]);
+    return res.json({ status: 'ok' });
+  } catch (error) {
+    console.error('Erro no healthcheck', error);
+    return res.status(500).json({ status: 'error', message: error.message });
+  }
+});
+
+app.get('/api/clients', authMiddleware, async (_req, res) => {
+  try {
+    const clients = await getClients();
+    return res.json(clients);
+  } catch (error) {
+    console.error('Erro ao consultar clientes', error);
+    return res.status(500).json({ message: 'Erro ao consultar clientes' });
+  }
+});
+
+app.use((req, res) => {
+  res.status(404).json({ message: 'Rota não encontrada' });
+});
+
+app.listen(config.port, () => {
+  console.log(`Servidor executando na porta ${config.port}`);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "3.9"
+
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    container_name: coder-sqlserver
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "StrongPassword!123"
+      MSSQL_PID: "Developer"
+    ports:
+      - "1433:1433"
+    volumes:
+      - ./sql/init:/init
+    command: ["/bin/bash", "/init/entrypoint.sh"]
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P StrongPassword!123 -Q 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    mem_limit: 2g
+    cpus: 1.0
+
+  mongo:
+    image: mongo:6
+    container_name: coder-mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: rootpassword
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./mongo/init:/docker-entrypoint-initdb.d:ro
+    mem_limit: 1g
+    cpus: 0.5
+
+  api:
+    build: ./api
+    container_name: coder-api
+    environment:
+      PORT: 3000
+      SQL_SERVER: sqlserver
+      SQL_DATABASE: CoderClients
+      SQL_USER: sa
+      SQL_PASSWORD: StrongPassword!123
+      SQL_ENCRYPT: "false"
+      MONGO_URI: mongodb://root:rootpassword@mongo:27017
+      MONGO_DB: coder
+      AUTH_COLLECTION: users
+    ports:
+      - "3000:3000"
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+      mongo:
+        condition: service_started
+    mem_limit: 1g
+    cpus: 1.0

--- a/mongo/init/init.js
+++ b/mongo/init/init.js
@@ -1,0 +1,18 @@
+db = db.getSiblingDB('coder');
+
+if (!db.getCollectionNames().includes('users')) {
+  db.createCollection('users');
+}
+
+db.users.updateOne(
+  { username: 'apiuser' },
+  {
+    $setOnInsert: {
+      username: 'apiuser',
+      password: 'apipassword123',
+      roles: ['api'],
+      createdAt: new Date()
+    }
+  },
+  { upsert: true }
+);

--- a/sql/init/entrypoint.sh
+++ b/sql/init/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+/opt/mssql/bin/sqlservr &
+SQL_PID=$!
+
+function cleanup() {
+  if ps -p "${SQL_PID}" > /dev/null; then
+    kill "${SQL_PID}"
+  fi
+}
+trap cleanup EXIT
+
+printf 'Waiting for SQL Server to be available'
+for i in {1..60}; do
+  if /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "${MSSQL_SA_PASSWORD}" -Q "SELECT 1" >/dev/null 2>&1; then
+    echo ' - ready'
+    break
+  fi
+  printf '.'
+  sleep 2
+  if [ "$i" -eq 60 ]; then
+    echo ' SQL Server failed to start in time' >&2
+    exit 1
+  fi
+done
+
+/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "${MSSQL_SA_PASSWORD}" -d master -i /init/setup.sql
+
+wait "${SQL_PID}"

--- a/sql/init/setup.sql
+++ b/sql/init/setup.sql
@@ -1,0 +1,25 @@
+IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = N'CoderClients')
+BEGIN
+    CREATE DATABASE CoderClients;
+END
+GO
+
+USE CoderClients;
+GO
+
+IF OBJECT_ID(N'dbo.Clients', N'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.Clients (
+        Id INT IDENTITY(1,1) PRIMARY KEY,
+        Name NVARCHAR(100) NOT NULL,
+        Email NVARCHAR(256) NOT NULL,
+        CreatedAt DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+
+    INSERT INTO dbo.Clients (Name, Email)
+    VALUES
+        (N'Ana Silva', N'ana.silva@example.com'),
+        (N'Bruno Oliveira', N'bruno.oliveira@example.com'),
+        (N'Carla Souza', N'carla.souza@example.com');
+END
+GO


### PR DESCRIPTION
## Summary
- add Docker-in-Docker devcontainer ready for Coder templates with Node.js tooling
- provide docker-compose stack with SQL Server 2019, MongoDB 6, and Node 22 API service
- implement API with Swagger docs, SQL client integration, and Mongo-backed authentication
- include initialization scripts and documentation for setting up the workspace

## Testing
- npm install *(fails: 403 Forbidden when downloading packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d43b29f49c832481ed9bc64f5b1e79