### PR TITLE
Use entrypoint for SQL Server bootstrap

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "1433:1433"
     volumes:
       - ./sql/init:/init
-    command: ["/bin/bash", "/init/entrypoint.sh"]
+    entrypoint: ["/bin/bash", "/init/entrypoint.sh"]
     healthcheck:
       test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P StrongPassword!123 -Q 'SELECT 1'"]
       interval: 10s


### PR DESCRIPTION
## Summary
- update the SQL Server service to use an explicit Bash entrypoint so the initialization script runs correctly

## Testing
- `docker compose up --build` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d443337fb88324a914cab8cfc21199