### PR TITLE
Create minimal Docker-in-Docker workspace with SQL Server and MongoDB

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Docker Engine, compose plugin, and Node.js 22 for local development
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release \
+        software-properties-common \
+    && install -m 0755 -d /etc/apt/keyrings \
+    # Docker repository
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list \
+    # Node.js 22 repository
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && chmod a+r /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin \
+        nodejs \
+        git \
+        unzip \
+        zip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Coder Docker-in-Docker Workspace",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": ["--privileged"],
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.vscode-node-azure-pack"
+      ]
+    }
+  },
+  "forwardPorts": [1433, 27017],
+  "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+npm-debug.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Workspace Docker in Docker para Coder
+
+Este template entrega um ambiente básico para workspaces Coder utilizando a estratégia Docker in Docker. O objetivo é fornecer um devcontainer pronto para uso com Docker, Node.js 22 e os serviços de banco de dados solicitados sem cargas de dados ou aplicações pré-configuradas.
+
+## Componentes
+
+- **Devcontainer** baseado em Ubuntu 22.04 com Docker Engine, plugin compose e Node.js 22 instalados.
+- **SQL Server 2019 Developer** executando em container, sem dados pré-carregados.
+- **MongoDB 6.0** executando em container, também sem dados iniciais.
+
+## Pré-requisitos
+
+- Um workspace Coder configurado para utilizar o template Docker in Docker.
+- Docker com suporte a containers privilegiados para que o daemon interno seja executado corretamente.
+
+## Utilização
+
+1. Abra o repositório no Coder e permita que o Visual Studio Code (ou code-server) construa o devcontainer definido em `.devcontainer/`.
+2. Dentro do terminal do devcontainer inicialize os bancos de dados conforme necessário:
+
+   ```bash
+   docker compose up -d
+   ```
+
+   Este comando provisiona o SQL Server e o MongoDB vazios, prontos para receber dados.
+
+3. Ajuste as credenciais conforme necessário editando `docker-compose.yml` antes de subir os serviços.
+4. Para encerrar o ambiente:
+
+   ```bash
+   docker compose down
+   ```
+
+   Os volumes nomeados `sqlserver-data` e `mongodb-data` preservam os dados gerados durante o uso.
+
+## Portas expostas
+
+| Serviço   | Porta |
+|-----------|-------|
+| SQL Server | 1433 |
+| MongoDB    | 27017 |
+
+## Próximos passos sugeridos
+
+- Criar aplicações Node.js dentro do próprio devcontainer utilizando o runtime pré-instalado.
+- Configurar scripts de seed ou migrações conforme os requisitos da sua aplicação.
+- Adicionar outras ferramentas de desenvolvimento necessárias ao seu fluxo de trabalho.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    container_name: workspace-sqlserver
+    restart: unless-stopped
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "StrongPassword!123"
+      MSSQL_PID: "Developer"
+    ports:
+      - "1433:1433"
+    volumes:
+      - sqlserver-data:/var/opt/mssql
+
+  mongodb:
+    image: mongo:6.0
+    container_name: workspace-mongodb
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb-data:/data/db
+
+volumes:
+  sqlserver-data:
+  mongodb-data:


### PR DESCRIPTION
## Summary
- rebuild the devcontainer image so it installs Docker Engine, compose, and Node.js 22 from official repositories
- simplify the devcontainer definition to focus on Docker-in-Docker with Node tooling and remove unused API setup
- trim the docker-compose stack to only SQL Server 2019 Developer and MongoDB 6 with persistent named volumes and refresh the README for the streamlined workspace

## Testing
- `docker compose config` *(fails: docker CLI not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d43b29f49c832481ed9bc64f5b1e79